### PR TITLE
Update Ui: Colour code the statuses

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -60,9 +60,38 @@ public class PersonCard extends UiPart<Region> {
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
         companyName.setText(person.getCompany().value);
-        status.getChildren().add(new Label(person.getStatus().value));
+        status.getChildren().add(handleStatusLabel(person));
         person.getProducts().stream()
                 .sorted(Comparator.comparing(product -> product.productName))
                 .forEach(product -> products.getChildren().add(new Label(product.productName)));
+    }
+
+    /**
+     * Creates and returns a styled {@code Label} representing the given {@code Person}'s status.
+     * The style depends on the status value ("uncontacted", "inprogress", "unsucessful", "successful").
+     *
+     * @param person The person whose status should be displayed.
+     * @return A {@code Label} containing the {@code Person}'s status displayed in text, with appropriate styling.
+     */
+    public Label handleStatusLabel(Person person) {
+        Label statusLabel = new Label(person.getStatus().value);
+        String status = person.getStatus().value.toLowerCase();
+        switch (status) {
+        case "uncontacted":
+            statusLabel.getStyleClass().add("status-uncontacted");
+            break;
+        case "inprogress":
+            statusLabel.getStyleClass().add("status-inprogress");
+            break;
+        case "unsuccessful":
+            statusLabel.getStyleClass().add("status-unsuccessful");
+            break;
+        case "successful":
+            statusLabel.getStyleClass().add("status-successful");
+            break;
+        default:
+            break;
+        }
+        return statusLabel;
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -344,12 +344,30 @@
 }
 
 #status .label {
-    -fx-text-fill: white;
-    -fx-background-color: #3e7b91;
     -fx-padding: 2 4 2 4;
     -fx-border-radius: 10;
     -fx-background-radius: 14;
     -fx-font-size: 11;
+}
+
+.status-uncontacted {
+    -fx-background-color: #889394;
+    -fx-text-fill: black !important;
+}
+
+.status-inprogress {
+    -fx-background-color: #e8dea9;
+    -fx-text-fill: black !important;
+}
+
+.status-unsuccessful {
+    -fx-background-color: #f23b16;
+    -fx-text-fill: black !important;
+}
+
+.status-successful {
+    -fx-background-color: #24e31e;
+    -fx-text-fill: black !important;
 }
 
 #products .label {

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -15,7 +15,7 @@
     <padding>
         <Insets top="8" left="30" right="30" bottom="4" />
     </padding>
-        <HBox spacing="5" minWidth="240" maxWidth="240" alignment="CENTER_LEFT">
+        <HBox spacing="5" minWidth="240" maxWidth="240" alignment="TOP_LEFT">
             <Label fx:id="id" styleClass="cell_big_label">
                 <minWidth>
                     <!-- Ensures that the label text is never truncated -->


### PR DESCRIPTION
All the status icons currently look the same. It us hard to see which status the person has at one glance.

Implementing different colour schemes for each status improves visibility and helps users see the status more quickly.

Resolves #77