### PR TITLE
Update User Guide - Edit Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -129,7 +129,7 @@ Format: `list`
 
 Edits an existing person in ClientHub.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​ [pdt/PRODUCT]…​`
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -137,10 +137,15 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 * When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
 * You can remove all the person’s tags by typing `t/` without
     specifying any tags after it.
+> [!NOTE]
+> 
+> Editing the product variable of a client completely deletes all existing products
+> tagged to the client, replacing it with your requested edits.
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
+*  `edit 3 pdt/Chicken` Clears all current products tag to the 3rd person, replacing it with `Chicken` only.
 
 ### Locating persons by name: `find`
 


### PR DESCRIPTION
Change the description of the user guide to inform the user that when
we edit the pdt, it deletes all existing products.

It can confuse.

Update the user guide.