### PR TITLE
Fix known issue for Help Command

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -143,6 +143,7 @@ public class MainWindow extends UiPart<Stage> {
         if (!helpWindow.isShowing()) {
             helpWindow.show();
         } else {
+            helpWindow.getRoot().setIconified(false);
             helpWindow.focus();
         }
     }


### PR DESCRIPTION
Help window does not open again if it was previously minimised. Users are unable to view the help window again if they do not click the minimised window. It can be confusing for users.

Allow help command to open the help window again even if it is already minimised.

Resolves #178